### PR TITLE
Use ExtUtils::CppGuess to set C++11 standard flag

### DIFF
--- a/.github/workflows/gcc-version.yml
+++ b/.github/workflows/gcc-version.yml
@@ -32,7 +32,6 @@ jobs:
         run: |
           eval $(perl -I ~/perl5/lib/perl5/ -Mlocal::lib)
           cpanm -n Dist::Zilla
-          cpanm -n git://github.com/zmughal/extutils-cppguess.git@standard-version-flag
           dzil authordeps --missing | cpanm -n
       - name: Make distribution
         shell: bash
@@ -96,7 +95,6 @@ jobs:
          cd /workdir
 
          echo "::group::install dependencies"
-         cpanm -n git://github.com/zmughal/extutils-cppguess.git@standard-version-flag
          cpanm --notest --installdeps .
          cpanm --notest HTTP::Tiny
          cpanm --notest Inline::CPP

--- a/.github/workflows/gcc-version.yml
+++ b/.github/workflows/gcc-version.yml
@@ -87,7 +87,7 @@ jobs:
          echo "::endgroup::"
 
          echo "::group::setup cpanm"
-         ( apt-get update || true ) && apt-get install -y --no-install-recommends curl git unzip libssl-dev zlib1g-dev
+         ( apt-get update || true ) && apt-get install -y --force-yes --no-install-recommends curl git unzip libssl-dev zlib1g-dev
          # libnet-ssleay-perl: Installed version (1.42) of Net::SSLeay is not in range '1.46'
          curl -L https://cpanmin.us | perl - App::cpanminus
          cpanm --local-lib=~/perl5 local::lib && eval $(perl -I ~/perl5/lib/perl5/ -Mlocal::lib)

--- a/.github/workflows/gcc-version.yml
+++ b/.github/workflows/gcc-version.yml
@@ -51,8 +51,8 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { gcc: '4.4' }
-          - { gcc: '4.6' }
+          - { gcc: '4.4', fails: true }
+          - { gcc: '4.6', fails: true }
           - { gcc: '4.8' }
           - { gcc: '6' }
           - { gcc: '7' }
@@ -95,13 +95,14 @@ jobs:
          cd /workdir
 
          echo "::group::install dependencies"
-         cpanm --notest --installdeps .
+         cpanm --verbose --notest --installdeps . || true
          cpanm --notest HTTP::Tiny
          cpanm --notest Inline::CPP
          echo "::endgroup::"
 
          echo "::group::run tests"
          export PERL5OPT="-MInline=noisy"
-         cpanm --verbose --test-only --test-args TEST_VERBOSE=1 .
+         ${{ fromJSON('[ "", "!" ]')[ matrix.fails || false ] }} \
+           cpanm --verbose --test-only --test-args TEST_VERBOSE=1 .
          echo "::endgroup::"
          EOF

--- a/.github/workflows/gcc-version.yml
+++ b/.github/workflows/gcc-version.yml
@@ -87,7 +87,7 @@ jobs:
          echo "::endgroup::"
 
          echo "::group::setup cpanm"
-         apt-get update && apt-get install -y --no-install-recommends curl git unzip libssl-dev zlib1g-dev
+         ( apt-get update || true ) && apt-get install -y --no-install-recommends curl git unzip libssl-dev zlib1g-dev
          # libnet-ssleay-perl: Installed version (1.42) of Net::SSLeay is not in range '1.46'
          curl -L https://cpanmin.us | perl - App::cpanminus
          cpanm --local-lib=~/perl5 local::lib && eval $(perl -I ~/perl5/lib/perl5/ -Mlocal::lib)

--- a/.github/workflows/gcc-version.yml
+++ b/.github/workflows/gcc-version.yml
@@ -45,6 +45,7 @@ jobs:
           path: ./build-dir
   ci-containers:
     needs: dist
+    name: "Run with GCC ${{ matrix.gcc }} (should fail?: ${{ matrix.fails || false }}) "
     runs-on: ubuntu-latest
     container: 
     strategy:

--- a/.github/workflows/gcc-version.yml
+++ b/.github/workflows/gcc-version.yml
@@ -52,7 +52,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { gcc: '4.4', fails: true }
+          #- { gcc: '4.4', fails: true }
           - { gcc: '4.6', fails: true }
           - { gcc: '4.8' }
           - { gcc: '6' }

--- a/.github/workflows/gcc-version.yml
+++ b/.github/workflows/gcc-version.yml
@@ -1,0 +1,109 @@
+name: gcc-version
+on:
+  push:
+    branches:
+      - '*'
+    tags-ignore:
+      - '*'
+  pull_request:
+jobs:
+  dist:
+    name: Make distribution using Dist::Zilla
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Cache ~/perl5
+        uses: actions/cache@v2
+        with:
+          key: ${{ runner.os }}-dist-locallib
+          path: ~/perl5
+      - name: Perl version
+        run: |
+          perl -v
+      - name: Install cpanm
+        run: |
+          curl -L https://cpanmin.us | perl - --sudo App::cpanminus
+      - name: Install local::lib
+        run: |
+          cpanm --local-lib=~/perl5 local::lib && eval $(perl -I ~/perl5/lib/perl5/ -Mlocal::lib)
+      - name: Install Dist::Zilla
+        shell: bash
+        run: |
+          eval $(perl -I ~/perl5/lib/perl5/ -Mlocal::lib)
+          cpanm -n Dist::Zilla
+          cpanm -n git://github.com/zmughal/extutils-cppguess.git@standard-version-flag
+          dzil authordeps --missing | cpanm -n
+      - name: Make distribution
+        shell: bash
+        run: |
+          eval $(perl -I ~/perl5/lib/perl5/ -Mlocal::lib)
+          dzil build --in build-dir
+      - name: Upload artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: dist
+          path: ./build-dir
+  ci-containers:
+    needs: dist
+    runs-on: ubuntu-latest
+    container: 
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { gcc: '4.4' }
+          - { gcc: '4.6' }
+          - { gcc: '4.8' }
+          - { gcc: '6' }
+          - { gcc: '7' }
+          - { gcc: '10' }
+    steps:
+      - name: Get dist artifact
+        uses: actions/download-artifact@v2
+        with:
+          name: dist
+
+      - run: |
+         cat <<'EOF' | docker run -i -v $(pwd):/workdir teeks99/gcc-ubuntu:${{ matrix.gcc }} bash
+         set -eu -o pipefail
+
+         echo "::group::compiler versions"
+         export CC_BIN_DIR="/tmp/cc-bin"
+         mkdir $CC_BIN_DIR
+         export PATH="$CC_BIN_DIR:$PATH"
+
+         for i in cc  gcc; do ln -s $(which gcc-${{ matrix.gcc }}) $CC_BIN_DIR/$i; done
+         for i in c++ g++; do ln -s $(which g++-${{ matrix.gcc }}) $CC_BIN_DIR/$i; done
+
+         cc --version
+         gcc --version
+         c++ --version
+         g++ --version
+         echo "::endgroup::"
+
+         echo "::group::perl version"
+         perl -V
+         echo "::endgroup::"
+
+         echo "::group::setup cpanm"
+         apt-get update && apt-get install -y --no-install-recommends curl git unzip libssl-dev zlib1g-dev
+         # libnet-ssleay-perl: Installed version (1.42) of Net::SSLeay is not in range '1.46'
+         curl -L https://cpanmin.us | perl - App::cpanminus
+         cpanm --local-lib=~/perl5 local::lib && eval $(perl -I ~/perl5/lib/perl5/ -Mlocal::lib)
+         echo "::endgroup::"
+
+         cd /workdir
+
+         echo "::group::install dependencies"
+         cpanm -n git://github.com/zmughal/extutils-cppguess.git@standard-version-flag
+         cpanm --notest --installdeps .
+         cpanm --notest HTTP::Tiny
+         cpanm --notest Inline::CPP
+         echo "::endgroup::"
+
+         echo "::group::run tests"
+         export PERL5OPT="-MInline=noisy"
+         cpanm --verbose --test-only --test-args TEST_VERBOSE=1 .
+         echo "::endgroup::"
+         EOF

--- a/alienfile
+++ b/alienfile
@@ -5,14 +5,17 @@ use warnings;
 
 use ExtUtils::CppGuess;
 
+my $guess = ExtUtils::CppGuess->new;
+my $cppstdflag = $guess->cpp_standard_flag('C++11');
+
+die "Need to have full C++11 support, compiler @{[ (split ' ', $guess->compiler_command)[0] ]} only supports $cppstdflag"
+	if ( $guess->is_gcc || $guess->is_clang ) && $cppstdflag =~ /\Qc++0x\E/;
+
 share {
 	requires 'Net::SSLeay' => 0;
 	requires 'IO::Socket::SSL' => 0;
 	requires 'File::Copy::Recursive' => 0;
 	requires 'Path::Tiny' => 0;
-
-	my $guess = ExtUtils::CppGuess->new;
-	my $cppstdflag = $guess->cpp_standard_flag('C++11');
 
 	plugin Download => (
 		url => 'https://github.com/nucleic/kiwi/archive/main.zip',

--- a/alienfile
+++ b/alienfile
@@ -3,11 +3,16 @@ use alienfile;
 use strict;
 use warnings;
 
+use ExtUtils::CppGuess;
+
 share {
 	requires 'Net::SSLeay' => 0;
 	requires 'IO::Socket::SSL' => 0;
 	requires 'File::Copy::Recursive' => 0;
 	requires 'Path::Tiny' => 0;
+
+	my $guess = ExtUtils::CppGuess->new;
+	my $cppstdflag = $guess->cpp_standard_flag('C++11');
 
 	plugin Download => (
 		url => 'https://github.com/nucleic/kiwi/archive/main.zip',
@@ -47,6 +52,7 @@ share {
 		my $cflags = "-I$prefix/include";
 		my $libs = "";
 
+		$build->runtime_prop->{cppstdflag}    = $cppstdflag;
 		$build->runtime_prop->{cflags}        = $cflags;
 		$build->runtime_prop->{cflags_static} = $cflags;
 		$build->runtime_prop->{libs}          = $libs;

--- a/dist.ini
+++ b/dist.ini
@@ -9,6 +9,9 @@ version = 0.002_002
 
 [AlienBuild]
 
+[Prereqs / ConfigureRequires]
+ExtUtils::CppGuess = 0.22
+
 [Prereqs / BuildRequires]
 URI = 0
 

--- a/dist.ini
+++ b/dist.ini
@@ -9,7 +9,7 @@ version = 0.002_002
 
 [AlienBuild]
 
-[Prereqs]
+[Prereqs / BuildRequires]
 URI = 0
 
 [Prereqs / Recommends]

--- a/dist.ini
+++ b/dist.ini
@@ -10,6 +10,7 @@ version = 0.002_002
 [AlienBuild]
 
 [Prereqs / ConfigureRequires]
+; authordep ExtUtils::CppGuess 0.22
 ExtUtils::CppGuess = 0.22
 
 [Prereqs / BuildRequires]

--- a/lib/Alien/Kiwisolver.pm
+++ b/lib/Alien/Kiwisolver.pm
@@ -16,7 +16,7 @@ sub Inline {
 	if( $lang =~ /^CPP$/ ) {
 		my $params = Alien::Base::Inline(@_);
 
-		$params->{CCFLAGSEX} = '-std=c++11';
+		$params->{CCFLAGSEX} = $self->runtime_prop->{cppstdflag};
 
 		$params->{PRE_HEAD} = <<'		EOF';
 		#if defined(_MSC_VER) || defined(__MINGW32__)


### PR DESCRIPTION
- Use C++ standard flag from ExtUtils::CppGuess
- GCC version testing

This is a demonstration of using the PR
<https://github.com/tsee/extutils-cppguess/pull/24> which introduces a way to
obtain a compiler flag for a given C++ standard.
